### PR TITLE
(WIP) Enable pre-shared key (PSK) authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,5 @@ RUN adduser stunnel --home /home/stunnel --shell /bin/bash --disabled-password -
 ADD https://github.com/kelseyhightower/confd/releases/download/v0.10.0/confd-0.10.0-linux-amd64 /usr/local/bin/confd
 
 RUN chmod +x /usr/local/bin/confd
-
 USER stunnel
-
 CMD ["./run.sh"]

--- a/README.md
+++ b/README.md
@@ -13,9 +13,36 @@ docker build --pull -t our.registry-url:platforms/stunnel:1 .
 docker push our.registry-url:platforms/stunnel:1
 ```
 
-## To Run
+## Running Stunnel
 
-We want the SSL certificate info in a json document with keys of `cert`, `key`, and `chain`. This simple snippet will do that for you. (You'll need to create the refered to PEM files.)
+Stunnel can authenticate using either pre-shared keys (PSK) or ssl certificates.
+Only one should be enabled at a time, otherwise certificate validation will take precedence.
+See [https://www.stunnel.org/auth.html](https://www.stunnel.org/auth.html)
+
+### Using PSK authentication
+
+Keys are passed in using the environment variables `STUNNEL_PSK_*`. For example, the following will set three PSK keys,
+
+```
+docker run \
+    -e STUNNEL_PSK_1={"one": "ilWilpyeuFroajpanbenkyeo"} \
+    -e STUNNEL_PSK_2={"two": "PlorrekCiphNoheHyecJejLu"} \
+    -e STUNNEL_PSK_3={"three": "shmooshuckWejIrEticyoams"} \
+    stunnel
+```
+
+generating a psk.txt file for stunnel of,
+
+```
+one:ilWilpyeuFroajpanbenkyeo
+two:PlorrekCiphNoheHyecJejLu
+three:shmooshuckWejIrEticyoams
+```
+
+### Using SSL authentication
+
+To use SSL authentication we format the certificate info in a json document with keys of `cert`, `key`, and `chain`. 
+This simple snippet will do that for you. (You'll need to create the refered to PEM files.)
 
 ```
 export STUNNEL_SSL="$(echo '{}' | jq -c \
@@ -25,15 +52,13 @@ export STUNNEL_SSL="$(echo '{}' | jq -c \
   '.cert = $cert | .chain = $chain | .key = $key')"
 ```
 
-And then run the container passing that environment variable we just created:
+And then run the container passing that environment variable we just created on the command line or through an env file.
 
 ```
 docker run --rm -ti \
   --env-file env.example -e "STUNNEL_SSL=$STUNNEL_SSL" \
   --expose 6379  ministryofjustice/stunnel
 ```
-
-But don't do it this way - it's just for testing - you should put the STUNNEL_SSL in the file you pass to `--env-file`
 
 ## To configure
 

--- a/confd/conf.d/stunnel.toml
+++ b/confd/conf.d/stunnel.toml
@@ -7,4 +7,6 @@ keys = [
   # For instance STUNNEL_FOO=123 would be available in a confd template as '{{ getv "/stunnel/foo" }}'
   # so STUNNEL_FOO_BAR would be "/stunnel/foo/bar"
   "/stunnel/service/",
+  "/stunnel/ssl",
+  "/stunnel/psk/",
 ]

--- a/confd/templates/cert.tmpl
+++ b/confd/templates/cert.tmpl
@@ -1,1 +1,3 @@
+{{ if exists "/stunnel/ssl" }}
 {{ $json := json (getv "/stunnel/ssl") }}{{ $json.cert }}
+{{ end }}

--- a/confd/templates/chain.tmpl
+++ b/confd/templates/chain.tmpl
@@ -1,1 +1,3 @@
+{{ if exists "/stunnel/ssl" }}
 {{ $json := json (getv "/stunnel/ssl") }}{{ $json.chain }}
+{{ end }}

--- a/confd/templates/key.tmpl
+++ b/confd/templates/key.tmpl
@@ -1,1 +1,3 @@
+{{ if exists "/stunnel/ssl" }}
 {{ $json := json (getv "/stunnel/ssl") }}{{ $json.key }}
+{{ end }}

--- a/confd/templates/stunnel.cnf.tmpl
+++ b/confd/templates/stunnel.cnf.tmpl
@@ -1,15 +1,15 @@
 foreground = yes
 syslog = no
 debug=4
-
 sslVersion=TLSv1.2
-ciphers=ECDHE-RSA-AES256-SHA384:AES256-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM
-
 {{range gets "/stunnel/service/*"}}
 [{{base .Key}}]
+{{ if ls "/stunnel/psk" }}PSKsecrets=/home/stunnel/psk.txt
+ciphers=PSK{{ end }}
+{{ if exists "/stunnel/ssl" }}ciphers=ECDHE-RSA-AES256-SHA384:AES256-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM
 CAfile=/home/stunnel/chain.pem
 cert=/home/stunnel/cert.pem
-key=/home/stunnel/key.pem
+key=/home/stunnel/key.pem{{ end }}
 {{range $key,$value := json .Value}}
 {{$key}}={{$value}}{{end}}
 {{end}}


### PR DESCRIPTION
This change adds the ability to use PSK with stunnel in addition to
the SSL certificate option.